### PR TITLE
refactor: move the code that changes the working directory to execute…

### DIFF
--- a/installer-prep
+++ b/installer-prep
@@ -9,7 +9,7 @@
 
 
 # Refer to the 'README' note at the beginning of 'linuxAIO' for more information.
-readonly C_CURRENT_LINUXAIO_REVISION=42
+readonly C_CURRENT_LINUXAIO_REVISION=43
 readonly C_MAIN_INSTALLER="nadeko-main-installer"
 
 ## Modify output text color.
@@ -30,6 +30,9 @@ E_ERROR="${E_RED}ERROR:${E_NC} "
 E_INFO="${E_BLUE}==>${E_NC} "
 E_NOTE="${E_CYAN}==>${E_NC} "
 export E_SUCCESS E_WARNING E_ERROR E_INFO E_NOTE
+
+export E_ROOT_DIR="$PWD"
+export E_INSTALLER_PREP="$E_ROOT_DIR/installer-prep"
 
 
 ####[ Functions ]#######################################################################
@@ -276,9 +279,9 @@ E_STDERR() {
 ####[ Trapping Logic ]##################################################################
 
 
+trap 'clean_exit "129" "true"' SIGHUP
 trap 'clean_exit "130" "true"' SIGINT
 trap 'clean_exit "143" "true"' SIGTERM
-trap 'clean_exit "129" "true"' SIGHUP
 trap 'clean_exit "$?" "true"' EXIT
 
 
@@ -292,16 +295,6 @@ if [[ $E_LINUXAIO_REVISION != "$C_CURRENT_LINUXAIO_REVISION" ]]; then
     # NOTE: The script will exit after the function has run.
     linuxAIO_update
 fi
-
-# Change the working directory to the location of the executed script.
-cd "${0%/*}" || {
-    echo "${E_ERROR}Failed to change working directory" >&2
-    echo "${E_NOTE}Change your working directory to that of the executed script"
-    clean_exit "1"
-}
-
-export E_ROOT_DIR="$PWD"
-export E_INSTALLER_PREP="$E_ROOT_DIR/installer-prep"
 
 
 ####[ Main ]############################################################################

--- a/installer-prep
+++ b/installer-prep
@@ -9,7 +9,7 @@
 
 
 # Refer to the 'README' note at the beginning of 'linuxAIO' for more information.
-readonly C_CURRENT_LINUXAIO_REVISION=43
+readonly C_CURRENT_LINUXAIO_REVISION=44
 readonly C_MAIN_INSTALLER="nadeko-main-installer"
 
 ## Modify output text color.

--- a/linuxAIO
+++ b/linuxAIO
@@ -108,7 +108,7 @@ nadekobot/output/data/xp_template.json"
 ###
 
 # 'linuxAIO' revision number.
-export E_LINUXAIO_REVISION=43
+export E_LINUXAIO_REVISION=44
 # The URL to the raw code of a specified script.
 export E_RAW_URL="https://raw.githubusercontent.com/$installer_repo/$installer_branch"
 
@@ -123,7 +123,7 @@ export E_RAW_URL="https://raw.githubusercontent.com/$installer_repo/$installer_b
 #   correct directory, the ${0%/*} will return 'linuxAIO' rather than '.', which will
 #   activate the '||' block since it's trying to `cd` into a file rather than a
 #   directory.
-if [[ -f linuxAIO ]]; then
+if [[ ! -f linuxAIO ]]; then
     cd "${0%/*}" || {
         echo "Failed to change working directory" >&2
         echo "Change your working directory to that of the executed script"

--- a/linuxAIO
+++ b/linuxAIO
@@ -108,9 +108,28 @@ nadekobot/output/data/xp_template.json"
 ###
 
 # 'linuxAIO' revision number.
-export E_LINUXAIO_REVISION=42
+export E_LINUXAIO_REVISION=43
 # The URL to the raw code of a specified script.
 export E_RAW_URL="https://raw.githubusercontent.com/$installer_repo/$installer_branch"
+
+
+####[ Prepping ]########################################################################
+
+
+## Change the working directory to that of the executed script.
+# NOTE:
+#   We need to check if 'linuxAIO' exists in the current directory because if the user
+#   executes this script with `bash linuxAIO` rather than `./linuxAIO`, while in the
+#   correct directory, the ${0%/*} will return 'linuxAIO' rather than '.', which will
+#   activate the '||' block since it's trying to `cd` into a file rather than a
+#   directory.
+if [[ -f linuxAIO ]]; then
+    cd "${0%/*}" || {
+        echo "Failed to change working directory" >&2
+        echo "Change your working directory to that of the executed script"
+        exit 1
+    }
+fi
 
 
 ####[ Main ]############################################################################


### PR DESCRIPTION
…d script, into 'linuxAIO'

Inside the 'installer-prep', the code will never change directories, as it's looking at the location of 'installer-prep', which will always be in the current directory. This is due to 'linxuAIO' not moving the working directory to the location of 'linuxAIO', if it was executed outside the correct directory. I just downloads 'installer-prep' into the current working dir.…d script, into 'linuxAIO'