### PR TITLE
Lib fixes and prioritize support for NadekoBot v7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [v6.2.0] - 2026-03-14
+
+⚠️ This release removes support for NadekoBot v6 in favor of v7. ⚠️
+
+### Changed 
+
+- ⚠️ Remove support for NadekoBot v6 in favor of v7.
+- Ensures the libs from the latest release of NadekoBot are used instead of overwriting them with the ones from the last installed version.
+
 ## [v6.1.0] - 2025-05-15
 
 ⚠️ This release removes support for NadekoBot v5 in favor of v6. ⚠️
@@ -450,7 +459,8 @@ Version 2.1.0 of the Nadeko Bash Scripts is a complete rewrite of the previous B
     - CentOS: 7
 - The option to run NadekoBot with auto-update.
 
-[unreleased]: https://github.com/StrangeRanger/nadeko-manager-scripts/compare/v6.1.0...HEAD
+[unreleased]: https://github.com/StrangeRanger/nadeko-manager-scripts/compare/v6.2.0...HEAD
+[v6.2.0]: https://github.com/StrangeRanger/nadeko-manager-scripts/releases/tag/v6.2.0
 [v6.1.0]: https://github.com/StrangeRanger/nadeko-manager-scripts/releases/tag/v6.1.0
 [v6.0.0]: https://github.com/StrangeRanger/nadeko-manager-scripts/releases/tag/v6.0.0
 [v5.0.0]: https://github.com/StrangeRanger/nadeko-manager-scripts/releases/tag/v5.0.0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Style Guide](https://img.shields.io/badge/code%20style-Style%20Guide-blueviolet)](https://bsg.hthompson.dev/)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/63b063408cea4065a5dbe8e7ba8fdfd2)](https://www.codacy.com/gh/StrangeRanger/nadeko-manager-scripts/dashboard?utm_source=github.com&utm_medium=referral&utm_content=StrangeRanger/nadeko-manager-scripts&utm_campaign=Badge_Grade)
 
-Nadeko Manager Scripts is a collection of Bash scripts that automates the complete lifecycle management of [NadekoBot](https://github.com/nadeko-bot/nadekobot) v6 on Linux systems. Designed for both beginners and experienced users, it eliminates the complexity of manual bot setup and maintenance through a simple, interactive interface.
+Nadeko Manager Scripts is a collection of Bash scripts that automates the complete lifecycle management of [NadekoBot](https://github.com/nadeko-bot/nadekobot) v7 on Linux systems. Designed for both beginners and experienced users, it eliminates the complexity of manual bot setup and maintenance through a simple, interactive interface.
 
 <details>
 <summary><strong>Table of Contents</strong></summary>
@@ -86,6 +86,7 @@ You can customize the behavior of the Nadeko Manager by editing a few variables 
   - Options:
     - `main` (stable, recommended)
     - `dev` (development, may be unstable)
+    - `NadekoV6` (for NadekoBot v6)
     - `NadekoV5` (for NadekoBot v5)
   - Default: `"main"`
 

--- a/m-bridge.bash
+++ b/m-bridge.bash
@@ -30,6 +30,7 @@ manager_repo="StrangeRanger/nadeko-manager-scripts"
 # Options:
 #   main     = Production-ready (latest stable code)
 #   dev      = Development code (may be unstable)
+#   NadekoV6 = Manager version for NadekoBot v6
 #   NadekoV5 = Manager version for NadekoBot v5
 #
 # Default: "main"
@@ -73,7 +74,7 @@ nadekobot/data/creds.yml"
 ### [ Non-configurable Variables ]
 ###
 
-export E_BRIDGE_REVISION=54
+export E_BRIDGE_REVISION=55
 export E_RAW_URL="https://raw.githubusercontent.com/$manager_repo/$manager_branch"
 
 

--- a/n-main-prep.bash
+++ b/n-main-prep.bash
@@ -13,7 +13,7 @@
 
 
 # See the 'README' note at the beginning of 'm-bridge.bash' for details.
-readonly C_LATEST_BRIDGE_REVISION=54
+readonly C_LATEST_BRIDGE_REVISION=55
 
 E_YELLOW="$(printf '\033[1;33m')"
 E_GREEN="$(printf '\033[0;32m')"

--- a/n-update.bash
+++ b/n-update.bash
@@ -312,12 +312,16 @@ popd >/dev/null || E_STDERR "Failed to change directory back to '$E_ROOT_DIR'" "
 
 if [[ -d $E_BOT_DIR ]]; then
     (
-        # Copy all the current files in the data directory, into the new one. Since all
-        # the files in the data directory have their own versioning, NadekoBot will
-        # handle any necessary migrations.
+        # Copy all the current files in the data directory, into the new one, while
+        # preserving the 'lib' directory from the new version. Since all the files in the
+        # data directory have their own versioning, NadekoBot will handle any other
+        # necessary migrations.
         echo "${E_INFO}Copying contents of '${C_CURRENT_DATA_DIR_PATH##*/}' to" \
             "'${C_NEW_DATA_DIR_PATH}'..."
+        mv "$C_NEW_DATA_DIR_PATH"/lib "$C_NEW_DATA_DIR_PATH"/lib.new || exit 1
         cp -rf "$C_CURRENT_DATA_DIR_PATH"/* "$C_NEW_DATA_DIR_PATH" || exit 1
+        rm -rf "${C_NEW_DATA_DIR_PATH:?}/lib" || exit 1
+        mv "$C_NEW_DATA_DIR_PATH"/lib.new "$C_NEW_DATA_DIR_PATH"/lib || exit 1
 
         set_creds
     ) || E_STDERR "An error occurred while copying data to '$C_TMP_BOT_DIR_PATH'" "$?"

--- a/n-update.bash
+++ b/n-update.bash
@@ -14,7 +14,7 @@
 
 C_TMP_DIR_PATH=$(mktemp -d -p /tmp nadekobot-XXXXXXXXXX)
 readonly C_TMP_DIR_PATH
-readonly C_NADEKO_MAJOR_VERSION="6"
+readonly C_NADEKO_MAJOR_VERSION="7"
 
 ## File and directory paths and names.
 readonly C_TMP_BOT_DIR_PATH="$C_TMP_DIR_PATH/$E_BOT_DIR"


### PR DESCRIPTION
This pull request introduces version 6.2.0 of the Nadeko Manager Scripts, focusing on dropping support for NadekoBot v6 in favor of v7 and ensuring the correct handling of library files during updates. The documentation and scripts have been updated to reflect these changes and to clarify versioning options for users.

**Major version and support changes:**

* Removed support for NadekoBot v6, making v7 the only supported version going forward. This is clearly stated in both the `CHANGELOG.md` and `README.md`.
* Updated the default major version in `n-update.bash` from `"6"` to `"7"`, ensuring all operations now target NadekoBot v7.

**Update process improvements:**

* Modified the update logic in `n-update.bash` to preserve the `lib` directory from the newly installed version of NadekoBot, rather than overwriting it with files from the previous installation. This prevents potential issues with outdated libraries.

**Documentation and versioning:**

* Added documentation for the new `NadekoV6` manager branch option in both `README.md` and `m-bridge.bash`, clarifying available versioning options even though v6 support is now deprecated. 
* Updated changelog and version references to reflect the new release (`v6.2.0`) and its comparison links.

**Internal version tracking:**

* Bumped the bridge revision number from `54` to `55` in both `m-bridge.bash` and `n-main-prep.bash` to track internal script changes. 