### PR TITLE
Refactor manager scripts and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ⚠️ This release removes support for NadekoBot v6 in favor of v7. ⚠️
 
-### Changed 
+### Changed
 
 - ⚠️ Remove support for NadekoBot v6 in favor of v7.
-- Ensures the libs from the latest release of NadekoBot are used instead of overwriting them with the ones from the last installed version.
+- Ensures the `lib` directory from the latest NadekoBot release is used instead of being overwritten by the one from the last installed version.
 
 ## [v6.1.0] - 2025-05-15
 

--- a/n-file-backup.bash
+++ b/n-file-backup.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Important Files Backup Script
+# NadekoBot Manager — Important Files Backup Script
 #
 # This script creates a backup of user-designated important files, as specified by the
 # $E_FILES_TO_BACK_UP variable defined in 'm-bridge.bash'.
@@ -11,8 +11,9 @@
 
 readonly C_CURRENT_BACKUP="important-files-backup"
 readonly C_OLD_BACKUP="important-files-backup.old"
-# shellcheck disable=SC2206
-#   Left unquoted to allow word splitting for array assignment.
+# shellcheck disable=SC2206,SC2153
+#   SC2206: Left unquoted to allow word splitting for array assignment.
+#   SC2153: $E_FILES_TO_BACK_UP is defined in 'm-bridge.bash'.
 readonly C_FILES_TO_BACK_UP=($E_FILES_TO_BACK_UP)
 C_TMP_BACKUP=$(mktemp -d -p /tmp important-nadeko-files-XXXXXXXXXX)
 readonly C_TMP_BACKUP
@@ -105,7 +106,7 @@ trap 'clean_exit "$?" "true"'  EXIT
 cd "$E_ROOT_DIR" || E_STDERR "Failed to change working directory to '$E_ROOT_DIR'" "1"
 echo "${E_NOTE}We will now back up the following files:"
 for file in "${C_FILES_TO_BACK_UP[@]}";
-    do echo "  ${E_CYAN}|${E_NC}    $file"
+    do echo "  ${E_CYAN}|${E_NC}  $file"
 done
 read -rp "${E_NOTE}Press [Enter] to continue"
 

--- a/n-main-prep.bash
+++ b/n-main-prep.bash
@@ -1,12 +1,12 @@
 #!/bin/bash
 #
-# NadekoBot Manager Bridge Script
+# NadekoBot Manager — Bridge Script
 #
 # This script acts as a bootstrapper for the NadekoBot Manager. It performs environment
 # validation (ensuring a 64-bit system and systemd are present), checks for bridge updates,
-# and downloads the main Manager script from a remote source. After setting up global
-# variables and performing initial checks, it executes the main Manager script and ensures
-# proper cleanup on exit.
+# and downloads the main Manager script from GitHub. After setting up global variables and
+# performing initial checks, it executes the main Manager script and ensures a clean exit by
+# performing necessary cleanup tasks.
 #
 ############################################################################################
 ####[ Exported and Global Variables ]#######################################################
@@ -15,14 +15,14 @@
 # See the 'README' note at the beginning of 'm-bridge.bash' for details.
 readonly C_LATEST_BRIDGE_REVISION=55
 
-E_YELLOW="$(printf '\033[1;33m')"
-E_GREEN="$(printf '\033[0;32m')"
-E_BLUE="$(printf '\033[0;34m')"
-E_CYAN="$(printf '\033[0;36m')"
-E_RED="$(printf '\033[1;31m')"
-E_NC="$(printf '\033[0m')"
-E_GREY="$(printf '\033[0;90m')"
-E_CLR_LN="$(printf '\r\033[K')"
+E_YELLOW=$'\033[1;33m'
+E_GREEN=$'\033[0;32m'
+E_BLUE=$'\033[0;34m'
+E_CYAN=$'\033[0;36m'
+E_RED=$'\033[1;31m'
+E_NC=$'\033[0m'
+E_GREY=$'\033[0;90m'
+E_CLR_LN=$'\r\033[K'
 export E_YELLOW E_GREEN E_BLUE E_CYAN E_RED E_NC E_GREY E_CLR_LN
 
 E_SUCCESS="${E_GREEN}==>${E_NC} "
@@ -33,7 +33,6 @@ E_NOTE="${E_CYAN}==>${E_NC} "
 E_IMP="${E_CYAN}IMPORTANT:${E_NC} "
 export E_SUCCESS E_WARN E_ERROR E_INFO E_NOTE E_IMP
 
-export E_BOT_DIR="nadekobot"
 export E_ROOT_DIR="$PWD"
 
 ###
@@ -98,8 +97,7 @@ clean_exit() {
 ###
 
 ####
-# Download the specified script from the remote location defined by $E_RAW_URL and grant it
-# executable permissions.
+# Download the specified script from $E_RAW_URL and grant it execute permissions.
 #
 # PARAMETERS:
 #   - $1: script_name (Required)

--- a/n-main.bash
+++ b/n-main.bash
@@ -225,6 +225,8 @@ trap 'exit_code_actions "143"' SIGTERM
 ####[ Main ]################################################################################
 
 
+# shellcheck disable=SC2153
+#   $E_ROOT_DIR is set in the main prep script and is used by multiple Manager scripts.
 cd "$E_ROOT_DIR" || E_STDERR "Failed to change working directory to '$E_ROOT_DIR'" "1"
 printf "%sWelcome to the NadekoBot Manager menu\n\n" "$E_CLR_LN"
 
@@ -254,7 +256,7 @@ while true; do
     ### [ Variable Checks ]
     ###
     ### These checks reassess the status or existence of certain services or programs (e.g.,
-    ### ccze, yt_dlp) each time the loop restarts, as their availability might change.
+    ### yt_dlp) each time the loop restarts, as their availability or status might change.
     ###
 
     if [[ -f "$E_YT_DLP_PATH" ]] || command -v yt-dlp &>/dev/null; then
@@ -297,7 +299,7 @@ while true; do
         fi
     ## If 'NadekoRun' exists, options 2 and 3 remain enabled.
     elif [[ -f NadekoRun ]]; then
-        ## If NadekoBot's service is running, options 4 and 5 remain enabled; otherwise,
+        ## If NadekoBot's service is running, options 4 and 5 remain enabled, otherwise,
         ## disable them.
         if [[ $E_BOT_SERVICE_STATUS == "active" ]]; then
             run_mode_status=" ${E_GREEN}(Running in this mode)${E_NC}"

--- a/n-main.bash
+++ b/n-main.bash
@@ -1,11 +1,11 @@
 #!/bin/bash
 #
-# NadekoBot Manager Menu Script
+# NadekoBot Manager — Menu Script
 #
 # This interactive script provides a menu-driven interface for managing the NadekoBot
-# service. It validates system prerequisites (e.g., Python3, ffmpeg, ccze, yt-dlp) and the
-# presence of required credentials, then dynamically enables or disables menu options based
-# on the current system state.
+# service. It validates prerequisites (e.g., Python3, ffmpeg, ccze, yt-dlp) and the presence
+# of required credentials, then dynamically enables or disables menu options based on the
+# current system state.
 #
 # The script allows you to download NadekoBot, start it (with or without auto-restart), stop
 # the service, view live service logs, install prerequisites, and back up important
@@ -17,8 +17,8 @@
 
 readonly C_CREDS="creds.yml"
 
+export E_BOT_DIR="nadekobot"
 export E_BOT_SERVICE="nadeko.service"
-export E_BOT_SERVICE_PATH="/etc/systemd/system/$E_BOT_SERVICE"
 export E_BOT_EXE="NadekoBot"
 export E_CREDS_EXAMPLE="creds_example.yml"
 export E_CREDS_PATH="$E_BOT_DIR/data/$C_CREDS"
@@ -42,7 +42,7 @@ export E_YT_DLP_PATH="$E_LOCAL_BIN/yt-dlp"
 #   - $1: exit_code (Required)
 #
 # RETURNS:
-#   - 0: If the exit code is one of 3, 4, 5, or 50, allowing the script to continue.
+#   - 0: If the exit code is one of 3, 4, 5, or 50, allow the script to continue.
 #
 # EXITS:
 #   - $exit_code: The exit code provided by the caller.
@@ -68,7 +68,7 @@ exit_code_actions() {
 #
 # RETURNS:
 #   - 0: If the token is set.
-#   - 1: If the token is not set.
+#   - 1: If the token is NOT set.
 is_token_set() {
     if grep -Eq '^token: '\'\''' "$E_CREDS_PATH"; then
         return 1
@@ -100,7 +100,7 @@ disabled_reasons() {
                 echo "${E_NOTE}    Use option 1 to download NadekoBot"
                 echo ""
             elif [[ ! -f $E_CREDS_PATH ]]; then
-                echo "${E_NOTE}  The '$C_CREDS' could not be found"
+                echo "${E_NOTE}  The '$C_CREDS' file could not be found"
                 echo "${E_NOTE}    Refer to the following guide for help:" \
                     "https://nadekobot.readthedocs.io/en/latest/creds-guide/"
                 echo ""
@@ -130,17 +130,6 @@ disabled_reasons() {
 ###
 ### [ Functions to be Exported ]
 ###
-
-####
-# Retrieve the current status of NadekoBot's service using systemctl and update the global
-# variable $E_BOT_SERVICE_STATUS accordingly.
-#
-# NEW GLOBALS:
-#   - E_BOT_SERVICE_STATUS: The current status of NadekoBot's service.
-E_GET_SERVICE_STATUS() {
-    E_BOT_SERVICE_STATUS=$(sudo systemctl is-active "$E_BOT_SERVICE")
-}
-export -f E_GET_SERVICE_STATUS
 
 ####
 # Halt NadekoBot's service if it is currently running, and optionally output a message
@@ -274,7 +263,7 @@ while true; do
         yt_dlp_installed=false
     fi
 
-    E_GET_SERVICE_STATUS
+    E_BOT_SERVICE_STATUS=$(sudo systemctl is-active "$E_BOT_SERVICE")
 
     ###
     ### [ Main Continued ]

--- a/n-prereqs.bash
+++ b/n-prereqs.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# NadekoBot Prerequisites Installer Script
+# NadekoBot Manager — Prerequisites Installer Script
 #
 # This script automates the installation of NadekoBot's prerequisites on supported Linux
 # distributions. It detects the system's OS and version, validates compatibility against a
@@ -98,26 +98,6 @@ declare -A -r C_MUSIC_PKG_MAPPING=(
 
 
 ####
-# Identify the system's distribution and version number.
-#
-# NEW GLOBALS:
-#   - C_DISTRO: The distribution name (or kernel name if '/etc/os-release' is absent).
-#   - C_VER: The full distribution version (or kernel version when falling back).
-#   - C_SVER: The major version number extracted from $C_VER.
-detect_sys_info() {
-    if [[ -f /etc/os-release ]]; then
-        . /etc/os-release
-        C_DISTRO="$ID"
-        C_VER="$VERSION_ID"  # Format: x.y.z...
-        C_SVER=${C_VER%%.*}  # Major version: x
-    else
-        C_DISTRO=$(uname -s)
-        C_VER=$(uname -r)
-        C_SVER=${C_VER%%.*}
-    fi
-}
-
-####
 # Display an exit message based on the provided exit code, and exit the script with the
 # specified code.
 #
@@ -161,19 +141,6 @@ clean_exit() {
     fi
 
     exit "$exit_code"
-}
-
-####
-# Display a message indicating that the current OS is unsupported for the automatic
-# installation of NadekoBot's prerequisites.
-#
-# EXITS:
-#   - 4: The current OS is unsupported.
-unsupported() {
-    echo "${E_ERROR}The Manager does not support the automatic installation and setup of" \
-        "NadekoBot's prerequisites for your OS" >&2
-    read -rp "${E_NOTE}Press [Enter] to return to the main menu"
-    exit 4
 }
 
 ####
@@ -411,7 +378,17 @@ trap 'clean_exit "$?"'  EXIT
 printf "%sWe will now install NadekoBot's prerequisites. " "$E_NOTE"
 read -rp "Press [Enter] to continue."
 
-detect_sys_info
+if [[ -f /etc/os-release ]]; then
+    # shellcheck disable=SC1091
+    . /etc/os-release
+    C_DISTRO="$ID"
+    C_VER="$VERSION_ID"  # Format: x.y.z...
+    C_SVER=${C_VER%%.*}  # Major version: x
+else
+    C_DISTRO=$(uname -s)
+    C_VER=$(uname -r)
+    C_SVER=${C_VER%%.*}
+fi
 
 for version in ${C_SUPPORTED_DISTROS[$C_DISTRO]}; do
     if [[ $version == "$C_VER" || $version == "$C_SVER" || $version == "any" ]]; then
@@ -426,4 +403,7 @@ for version in ${C_SUPPORTED_DISTROS[$C_DISTRO]}; do
     fi
 done
 
-unsupported
+echo "${E_ERROR}The Manager does not support the automatic installation and setup of" \
+    "NadekoBot's prerequisites for your OS" >&2
+read -rp "${E_NOTE}Press [Enter] to return to the main menu"
+exit 4

--- a/n-runner.bash
+++ b/n-runner.bash
@@ -1,9 +1,9 @@
 #!/bin/bash
 #
-# NadekoBot Service Runner Configuration Script
+# NadekoBot Manager — Service Runner Configuration Script
 #
 # This script configures the systemd service for NadekoBot and prepares the runner script
-# (NadekoRun) based on the chosen run mode. Depending on the value of E_RUNNER_CODENAME, it
+# (NadekoRun) based on the chosen run mode. Depending on the value of $E_RUNNER_CODENAME, it
 # either creates a standard or an auto-restart version of the runner script, writes or
 # updates the service file accordingly, and then starts or restarts the service. Finally, it
 # displays the service logs to provide immediate feedback on the operation.
@@ -12,7 +12,7 @@
 ####[ Global Variables ]####################################################################
 
 
-C_BOT_SERVICE_PATH="/etc/systemd/system/$E_BOT_SERVICE"
+readonly C_BOT_SERVICE_PATH="/etc/systemd/system/$E_BOT_SERVICE"
 
 ## Determine the action to be performed on the NadekoBot service based on its code name.
 if [[ $E_RUNNER_CODENAME == "NadekoRun" ]]; then

--- a/n-runner.bash
+++ b/n-runner.bash
@@ -12,6 +12,8 @@
 ####[ Global Variables ]####################################################################
 
 
+C_BOT_SERVICE_PATH="/etc/systemd/system/$E_BOT_SERVICE"
+
 ## Determine the action to be performed on the NadekoBot service based on its code name.
 if [[ $E_RUNNER_CODENAME == "NadekoRun" ]]; then
     readonly C_ACTION_LOWER="disable"    # Used with 'systemctl'.
@@ -106,7 +108,7 @@ trap 'clean_exit "$?" "true"'  EXIT
 ####[ Main ]################################################################################
 
 
-if [[ -f $E_BOT_SERVICE_PATH ]]; then
+if [[ -f $C_BOT_SERVICE_PATH ]]; then
     echo "${E_INFO}Updating '$E_BOT_SERVICE'..."
 else
     echo "${E_INFO}Creating '$E_BOT_SERVICE'..."
@@ -114,7 +116,7 @@ fi
 
 # shellcheck disable=SC2015
 #   E_STDERR should be executed if either command fails.
-echo "$C_BOT_SERVICE_CONTENT" | sudo tee "$E_BOT_SERVICE_PATH" &>/dev/null \
+echo "$C_BOT_SERVICE_CONTENT" | sudo tee "$C_BOT_SERVICE_PATH" &>/dev/null \
     && sudo systemctl daemon-reload \
     || E_STDERR "Failed to create '$E_BOT_SERVICE'" "3" \
         "${E_NOTE}This service must exist for NadekoBot to work"

--- a/n-update-bridge.bash
+++ b/n-update-bridge.bash
@@ -31,7 +31,7 @@ revert() {
 }
 
 ####
-# Download the latest 'm-bridge.bash' from $E_RAW_URL and makes it executable.
+# Download the latest 'm-bridge.bash' from $E_RAW_URL and make it executable.
 download_bridge() {
     echo "${E_INFO}Downloading latest version of 'm-bridge.bash'..."
     curl -O "$E_RAW_URL"/m-bridge.bash || {

--- a/n-update-bridge.bash
+++ b/n-update-bridge.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# m-bridge.bash Update and Configuration Migration Script
+# NadekoBot Manager — m-bridge.bash Update and Configuration Migration Script
 #
 # This script automates the update process for 'm-bridge.bash'. It checks for a newer
 # version of the script (or its legacy counterpart 'linuxAIO'), backs up the current version
@@ -13,7 +13,7 @@
 
 
 ####
-# Reverts changes made to 'm-bridge.bash' if the script is interrupted or fails.
+# Revert changes made to 'm-bridge.bash' if the script is interrupted or fails.
 #
 # EXITS:
 #   - 1: Terminates the script immediately.
@@ -31,7 +31,7 @@ revert() {
 }
 
 ####
-# Downloads the latest 'm-bridge.bash' from $E_RAW_URL and makes it executable.
+# Download the latest 'm-bridge.bash' from $E_RAW_URL and makes it executable.
 download_bridge() {
     echo "${E_INFO}Downloading latest version of 'm-bridge.bash'..."
     curl -O "$E_RAW_URL"/m-bridge.bash || {
@@ -42,7 +42,7 @@ download_bridge() {
 }
 
 ####
-# Transfers configuration settings from the old 'm-bridge.bash' to the new version.
+# Transfer configuration settings from the old 'm-bridge.bash' to the new version.
 transfer_bridge_data() {
     local manager_branch
     local manager_branch_found
@@ -69,7 +69,7 @@ transfer_bridge_data() {
 }
 
 ####
-# Notifies the user that the current Manager version (revision 40 or earlier) is very
+# Notify the user that the current Manager version (revision 40 or earlier) is very
 # outdated and does not support the automatic transfer of configurations to the new
 # 'm-bridge.bash'.
 #
@@ -87,7 +87,7 @@ revision_40() {
 }
 
 ####
-# Performs additional checks and modifications for 'm-bridge.bash' revision 45 and earlier,
+# Perform additional checks and modifications for 'm-bridge.bash' revision 45 and earlier,
 # ensuring compatibility with updated structures.
 #
 # RETURNS:
@@ -113,11 +113,11 @@ revision_45() {
             "NadekoBot before continuing."
     fi
 
-    revision_47.5 "$additional_changes"
+    revision_47_5 "$additional_changes"
 }
 
 ####
-# Updates variable names in 'm-bridge.bash.old' to match the new naming conventions.
+# Update variable names in 'm-bridge.bash.old' to match the new naming conventions.
 #
 # PARAMETERS:
 #   - $1: additional_changes (Optional, Default: false)
@@ -126,7 +126,7 @@ revision_45() {
 #
 # EXITS:
 #   - 1: If the function fails to update the variables in 'm-bridge.bash'.
-revision_47.5() {
+revision_47_5() {
     local additional_changes="${1:-false}"
 
     if [[ $additional_changes == true ]]; then
@@ -232,7 +232,7 @@ elif [[ $E_LINUXAIO_REVISION -le 47 && $E_CURRENT_LINUXAIO_REVISION == 47.5 ]]; 
     if (( E_LINUXAIO_REVISION <= 45 )); then
         revision_45
     else
-        revision_47.5
+        revision_47_5
     fi
 
     transfer_bridge_data

--- a/n-update.bash
+++ b/n-update.bash
@@ -1,15 +1,15 @@
 #!/bin/bash
 #
-# NadekoBot Setup/Update Script
+# NadekoBot Manager — Setup/Update Script
 #
-# This script automates the update process for NadekoBot (major version 6). It stops the
+# This script automates the update process for NadekoBot (major version 7). It stops the
 # NadekoBot service if it is active, retrieves available releases from the GitHub API, and
 # prompts the user to select a version for installation. The script then downloads and
 # extracts the chosen archive, migrates credentials, the database, and other data, then
 # replaces the existing installation with the new version.
 #
 ############################################################################################
-####[ Variables ]###########################################################################
+####[ Global Variables ]####################################################################
 
 
 C_TMP_DIR_PATH=$(mktemp -d -p /tmp nadekobot-XXXXXXXXXX)
@@ -62,7 +62,7 @@ revert_changes() {
 }
 
 ####
-# Clean up temporary files and directories, and attempts to restore the original $E_BOT_DIR
+# Clean up temporary files and directories, and attempt to restore the original $E_BOT_DIR
 # if an error or premature exit is detected.
 #
 # PARAMETERS:
@@ -154,8 +154,8 @@ compare_versions() {
 }
 
 ####
-# Retrieve all available NadekoBot versions from the GitHub API and prompts the user to
-# select one for installation.
+# Retrieve all available NadekoBot versions, given $C_NADEKO_MAJOR_VERSION, from the GitHub
+# API and prompts the user to select one for installation.
 #
 # NEW GLOBALS:
 #   - C_BOT_VERSION: The selected NadekoBot version to install.
@@ -183,7 +183,7 @@ fetch_versions() {
 
     ## Get current version of NadekoBot, if it's installed.
     if [[ -f $E_ROOT_DIR/$E_BOT_DIR/$E_BOT_EXE ]]; then
-        current_version=$("$E_ROOT_DIR"/"$E_BOT_DIR"/"$E_BOT_EXE" --version)
+        current_version=$("$E_ROOT_DIR/$E_BOT_DIR/$E_BOT_EXE" --version)
 
         if [[ ! $current_version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "${E_WARN}Unable to determine the current version of NadekoBot"
@@ -302,9 +302,9 @@ tar -xzf "$C_ARCHIVE_NAME" -C "$E_BOT_DIR" --strip-components=1 \
 popd >/dev/null || E_STDERR "Failed to change directory back to '$E_ROOT_DIR'" "1"
 
 ###
-### [ Move Credentials, Database, and Other Data ]
+### [ Move Data ]
 ###
-### Moves the credentials, database, and other NadekoBot data to the new version directory.
+### Move the credentials, database, and other NadekoBot data to the new version's directory.
 ### In case '$E_BOT_DIR' already exists, it is renamed to '$C_BOT_DIR_OLD' (with a further
 ### fallback of '$C_BOT_DIR_OLD_OLD'), making it easier to revert to a previous version if
 ### needed.
@@ -318,10 +318,14 @@ if [[ -d $E_BOT_DIR ]]; then
         # necessary migrations.
         echo "${E_INFO}Copying contents of '${C_CURRENT_DATA_DIR_PATH##*/}' to" \
             "'${C_NEW_DATA_DIR_PATH}'..."
-        mv "$C_NEW_DATA_DIR_PATH"/lib "$C_NEW_DATA_DIR_PATH"/lib.new || exit 1
-        cp -rf "$C_CURRENT_DATA_DIR_PATH"/* "$C_NEW_DATA_DIR_PATH" || exit 1
-        rm -rf "${C_NEW_DATA_DIR_PATH:?}/lib" || exit 1
-        mv "$C_NEW_DATA_DIR_PATH"/lib.new "$C_NEW_DATA_DIR_PATH"/lib || exit 1
+        if [[ -d "$C_NEW_DATA_DIR_PATH/lib" ]]; then
+            mv "$C_NEW_DATA_DIR_PATH"/lib "$C_NEW_DATA_DIR_PATH"/lib.new || exit 1
+            cp -rf "$C_CURRENT_DATA_DIR_PATH"/* "$C_NEW_DATA_DIR_PATH" || exit 1
+            rm -rf "${C_NEW_DATA_DIR_PATH:?}/lib" || exit 1
+            mv "$C_NEW_DATA_DIR_PATH"/lib.new "$C_NEW_DATA_DIR_PATH"/lib || exit 1
+        else
+            cp -rf "$C_CURRENT_DATA_DIR_PATH"/* "$C_NEW_DATA_DIR_PATH" || exit 1
+        fi
 
         set_creds
     ) || E_STDERR "An error occurred while copying data to '$C_TMP_BOT_DIR_PATH'" "$?"


### PR DESCRIPTION
This pull request primarily focuses on improving code clarity, maintainability, and consistency across the NadekoBot Manager Bash scripts. It includes updates to documentation, variable handling, and error messaging, as well as some refactoring to simplify the codebase and improve maintainability. The changes are grouped below by theme.

**Documentation and Clarity Improvements:**

* Updated script headers and comments in several files (e.g., `n-main-prep.bash`, `n-main.bash`, `n-prereqs.bash`, `n-runner.bash`, `n-update-bridge.bash`, `n-file-backup.bash`) to clarify their purpose, improve readability, and ensure consistency. 
* Enhanced and clarified inline comments and function descriptions throughout the scripts.

**Variable Handling and Consistency:**

* Standardized the export and assignment of important environment variables, such as `E_BOT_DIR`, `E_BOT_SERVICE`, and color codes, to ensure they are set correctly and consistently across scripts.
* Refactored the handling of the systemd service path by introducing a new constant `C_BOT_SERVICE_PATH` and updating its usage.
* Improved `shellcheck` annotations and clarified the use of externally set variables to avoid false warnings.

**Code Simplification and Refactoring:**

* Inlined or removed small utility functions, such as the system info detection and unsupported OS handler in `n-prereqs.bash`, replacing them with direct code for simplicity. 
* Removed the now-unnecessary exported function for retrieving service status in `n-main.bash`, replacing it with a direct command.

**Error Handling and Messaging:**

* Improved and clarified error and status messages, including more precise language and guidance for users.

**Other Minor Fixes:**

* Fixed a typo in a function call (`revision_47.5` → `revision_47_5`) in the update bridge script.

These updates collectively improve the maintainability, clarity, and reliability of the NadekoBot Manager scripts.