### PR TITLE
Clarify exit code documentation and adjust install abort handling

### DIFF
--- a/n-prereqs.bash
+++ b/n-prereqs.bash
@@ -185,7 +185,7 @@ install_ccze_arch() {
         if [[ ! $confirm =~ ^y ]]; then
             echo "${E_WARN}Installation of 'ccze' and its build tools aborted by user" >&2
             echo "${E_WARN}'ccze' is required to colorize NadekoBot's logs" >&2
-            return 1
+            return
         fi
 
         echo "${E_INFO}Installing necessary build tools..."
@@ -219,7 +219,7 @@ install_ccze_arch() {
 #       - A list of other packages required by the Manager.
 #
 # EXITS:
-#   - $?: If any of the installation steps fail.
+#   - Non-zero exit code: If any of the installation steps fail.
 install_prereqs() {
     local install_cmd="$1"
     local update_cmd="$2"


### PR DESCRIPTION
This pull request makes minor improvements to the `n-prereqs.bash` script, focusing on error handling and documentation clarity.

Error handling:

* The `install_ccze_arch()` function now returns without a status code when the user aborts the installation, instead of explicitly returning `1`.

Documentation:

* Updated the comment for the `install_prereqs()` function to clarify that a non-zero exit code is returned if any installation steps fail.